### PR TITLE
Fix out of bounds error (#2)

### DIFF
--- a/src/Data/Transient/WordMap/Internal.hs
+++ b/src/Data/Transient/WordMap/Internal.hs
@@ -407,7 +407,7 @@ plugT hint k z on@(TNode ok n m as)
           if ptrEq oz z
             then return on -- but we arent changing it
             else do -- here we are, and we need to copy on write
-              bs <- cloneSmallMutableArray as 0 odm
+              bs <- cloneSmallMutableArray as 0 (sizeOfSmallMutableArray as)
               writeSmallArray bs odm z
               apply hint bs
               return (TNode ok n m bs)


### PR DESCRIPTION
Cloning *up to* `odm` is a good way to get UB in the next line.
I'm pretty sure we want to clone the whole array, hence that's what I do in this commit.

Fixes #2.